### PR TITLE
fix(ci): add pull-requests:write permission for npm audit autofix

### DIFF
--- a/.github/workflows/build-projects.yml
+++ b/.github/workflows/build-projects.yml
@@ -17,6 +17,7 @@ jobs:
       contents: write
       packages: write
       security-events: write
+      pull-requests: write
     with:
       tool: "npm"
       format: "run format"


### PR DESCRIPTION
Adds `pull-requests: write` to the caller workflow — required for the nested `npm-audit-autofix.yml` job. See tehw0lf/workflows#63.