### PR TITLE
test(e2e): add Playwright E2E tests for all three state management approaches

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,7 +1,6 @@
-import { defineConfig } from '@playwright/test';
-import { nxE2EPreset } from '@nx/playwright/preset';
-
 import { workspaceRoot } from '@nx/devkit';
+import { nxE2EPreset } from '@nx/playwright/preset';
+import { defineConfig } from '@playwright/test';
 
 // For CI, you may want to set BASE_URL to the deployed application.
 const baseURL = process.env['BASE_URL'] || 'http://localhost:4200';

--- a/e2e/src/example.spec.ts
+++ b/e2e/src/example.spec.ts
@@ -1,8 +1,0 @@
-import { test, expect } from '@playwright/test';
-
-test('has title', async ({ page }) => {
-  await page.goto('/');
-
-  // Expect h1 to contain a substring.
-  expect(await page.locator('h1').innerText()).toContain('Welcome');
-});

--- a/e2e/src/local-storage.spec.ts
+++ b/e2e/src/local-storage.spec.ts
@@ -1,0 +1,70 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('LocalStorage state', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+  });
+
+  test('container starts dark on initial load', async ({ page }) => {
+    const container = page.locator('.local-storage');
+    await expect(container).toHaveClass(/dark/);
+  });
+
+  test('container respects dark theme from localStorage on reload', async ({ page }) => {
+    await page.evaluate(() => localStorage.setItem('theme', 'dark'));
+    await page.reload();
+    await expect(page.locator('.local-storage')).toHaveClass(/dark/);
+  });
+
+  // BUG: AppComponent constructor always sets 'dark', overriding any existing localStorage value on reload
+  test.fail('container respects light theme from localStorage on reload', async ({ page }) => {
+    await page.evaluate(() => localStorage.setItem('theme', 'light'));
+    await page.reload();
+    await expect(page.locator('.local-storage')).toHaveClass(/light/);
+  });
+
+  test('clicking the container toggles theme to light in localStorage', async ({ page }) => {
+    const container = page.locator('.local-storage');
+
+    await container.click();
+
+    const theme = await page.evaluate(() => localStorage.getItem('theme'));
+    expect(theme).toBe('light');
+  });
+
+  test('clicking the container twice restores dark theme in localStorage', async ({ page }) => {
+    const container = page.locator('.local-storage');
+
+    await container.click();
+    await container.click();
+
+    const theme = await page.evaluate(() => localStorage.getItem('theme'));
+    expect(theme).toBe('dark');
+  });
+
+  // BUG: AppComponent constructor always sets 'dark', overriding any existing localStorage value on reload
+  test.fail('light theme persists and renders correctly after reload', async ({ page }) => {
+    const container = page.locator('.local-storage');
+
+    await container.click();
+    const themeAfterClick = await page.evaluate(() => localStorage.getItem('theme'));
+    expect(themeAfterClick).toBe('light');
+
+    await page.reload();
+
+    await expect(page.locator('.local-storage')).toHaveClass(/light/);
+  });
+
+  test('localStorage state does not affect signal or subject blocks', async ({ page }) => {
+    const container = page.locator('.local-storage');
+
+    await container.click();
+
+    for (const block of await page.locator('.signal').all()) {
+      await expect(block).toHaveClass(/dark/);
+    }
+    for (const block of await page.locator('.subject').all()) {
+      await expect(block).toHaveClass(/dark/);
+    }
+  });
+});

--- a/e2e/src/signal.spec.ts
+++ b/e2e/src/signal.spec.ts
@@ -1,0 +1,54 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Signal state', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+  });
+
+  test('each signal block starts dark', async ({ page }) => {
+    const blocks = page.locator('.signal');
+    for (const block of await blocks.all()) {
+      await expect(block).toHaveClass(/dark/);
+    }
+  });
+
+  test('clicking one signal block toggles only that block', async ({ page }) => {
+    const blocks = page.locator('.signal');
+    const first = blocks.nth(0);
+    const second = blocks.nth(1);
+    const third = blocks.nth(2);
+
+    await first.click();
+
+    await expect(first).toHaveClass(/light/);
+    await expect(second).toHaveClass(/dark/);
+    await expect(third).toHaveClass(/dark/);
+  });
+
+  test('clicking the same signal block twice returns it to dark', async ({ page }) => {
+    const block = page.locator('.signal').first();
+
+    await block.click();
+    await expect(block).toHaveClass(/light/);
+
+    await block.click();
+    await expect(block).toHaveClass(/dark/);
+  });
+
+  test('signal blocks toggle independently', async ({ page }) => {
+    const blocks = page.locator('.signal');
+    const first = blocks.nth(0);
+    const second = blocks.nth(1);
+
+    await first.click();
+    await second.click();
+
+    await expect(first).toHaveClass(/light/);
+    await expect(second).toHaveClass(/light/);
+
+    await first.click();
+
+    await expect(first).toHaveClass(/dark/);
+    await expect(second).toHaveClass(/light/);
+  });
+});

--- a/e2e/src/subject.spec.ts
+++ b/e2e/src/subject.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Subject/Service state', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+  });
+
+  test('each subject block starts dark', async ({ page }) => {
+    const blocks = page.locator('.subject');
+    for (const block of await blocks.all()) {
+      await expect(block).toHaveClass(/dark/);
+    }
+  });
+
+  test('clicking one subject block toggles all subject blocks', async ({ page }) => {
+    const blocks = page.locator('.subject');
+    const first = blocks.nth(0);
+
+    await first.click();
+
+    for (const block of await blocks.all()) {
+      await expect(block).toHaveClass(/light/);
+    }
+  });
+
+  test('clicking a subject block twice returns all to dark', async ({ page }) => {
+    const blocks = page.locator('.subject');
+    const first = blocks.nth(0);
+
+    await first.click();
+    await first.click();
+
+    for (const block of await blocks.all()) {
+      await expect(block).toHaveClass(/dark/);
+    }
+  });
+
+  test('toggling from any subject block affects all others', async ({ page }) => {
+    const blocks = page.locator('.subject');
+    const second = blocks.nth(1);
+    const third = blocks.nth(2);
+
+    await third.click();
+    await expect(second).toHaveClass(/light/);
+
+    await second.click();
+    await expect(third).toHaveClass(/dark/);
+  });
+
+  test('subject blocks do not affect signal blocks', async ({ page }) => {
+    const subjectBlock = page.locator('.subject').first();
+    const signalBlocks = page.locator('.signal');
+
+    await subjectBlock.click();
+
+    for (const block of await signalBlocks.all()) {
+      await expect(block).toHaveClass(/dark/);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Replaces the placeholder `example.spec.ts` with meaningful Playwright E2E tests
- Covers all three state management patterns demonstrated in the app:
  - **Signal**: each block toggles independently (local state isolation)
  - **Subject/Service**: clicking any block updates all others via shared BehaviorSubject
  - **LocalStorage**: theme persists across page reloads

## Bug discovered

`AppComponent` constructor unconditionally calls `localStorage.setItem('theme', 'dark')` on every page load, overwriting any previously stored `'light'` value. Two tests are marked `test.fail()` to document this behaviour until it is fixed.

## Test plan

- [ ] `npx nx e2e e2e` passes with 16/16 tests (14 passing, 2 expected failures)
- [ ] Signal blocks toggle independently and do not affect each other
- [ ] Subject blocks all update when any one is clicked
- [ ] LocalStorage theme is written correctly and survives a page reload

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive end-to-end tests for theme persistence and localStorage state management
  * Added tests for theme toggling behavior (light/dark modes across UI components)
  * Removed outdated welcome page test

* **Chores**
  * Reorganized test configuration imports for consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->