### PR TITLE
fix(ci): fix artifact name mismatch and parallelize security scan jobs

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -46,8 +46,6 @@ jobs:
   download_artifacts:
     name: Download Build Artifacts
     runs-on: ubuntu-latest
-    needs: scan_source
-    if: always()
 
     steps:
       - name: Download latest dist artifacts from CI
@@ -62,7 +60,7 @@ jobs:
         if: hashFiles('dist/**/*') != ''
         uses: actions/upload-artifact@v4
         with:
-          name: dist
+          name: build
           path: dist/
           retention-days: 1
 


### PR DESCRIPTION
## Summary
- Rename upload artifact from `dist` to `build` to match what `security-scan-artifacts.yml` expects — artifact scans were silently skipped before this fix
- Remove `needs: scan_source` and `if: always()` from `download_artifacts` job; the two jobs are independent and now run in parallel

## Root Cause
`security-scan-artifacts.yml` checks for an artifact named `build`, but the `download_artifacts` job was re-uploading under the name `dist`. The existence check returned `false`, causing all scan steps to be silently skipped — workflows appeared green but never actually scanned artifacts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions security monitoring workflow configuration to streamline job execution and improve build artifact handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->